### PR TITLE
Update gingerd.service.fedora

### DIFF
--- a/contrib/gingerd.service.fedora
+++ b/contrib/gingerd.service.fedora
@@ -1,7 +1,3 @@
-[Unit]
-Requires=wokd.service
-After=wokd.service
-
 [Service]
 Nice=0
 PrivateTmp=yes


### PR DESCRIPTION
Dependency on wokd.service does not make sense, since this file is a modifier for wokd.service. systemd already ignores it:
~  systemd-analyze verify wokd.service
wokd.service: Dependency After=wokd.service dropped
wokd.service: Dependency After=wokd.service dropped